### PR TITLE
refactor: interface → type に変更（コーディングルール準拠）

### DIFF
--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -2,29 +2,29 @@ export type Severity = "Critical" | "High" | "Medium" | "Low";
 export type Status = "analyzing" | "completed" | "failed";
 export type Role = "Admin" | "Editor" | "Viewer";
 
-export interface Vulnerability {
+export type Vulnerability = {
   id: string;
   packageName: string;
   version: string;
   severity: Severity;
   cve: string;
   description: string;
-}
+};
 
-export interface Team {
+export type Team = {
   id: string;
   name: string;
-}
+};
 
-export interface Member {
+export type Member = {
   id: string;
   name: string;
   email: string;
   role: Role;
   avatarUrl?: string;
-}
+};
 
-export interface Project {
+export type Project = {
   id: string;
   teamId: string;
   name: string;
@@ -34,4 +34,4 @@ export interface Project {
   vulnerabilities: Vulnerability[];
   pkgCount: number;
   errorMessage?: string;
-}
+};


### PR DESCRIPTION
## 概要

型定義を `interface` から `type` に変更しました（コーディングルール準拠）。

## 変更内容

- `interface Vulnerability` → `type Vulnerability`
- `interface Team` → `type Team`
- `interface Member` → `type Member`
- `interface Project` → `type Project`

## 理由

コーディングルールで「継承や宣言マージが不要なら `type` を使う」と定めているため。