### PR TITLE
refactor: 未使用の型 Status, Role を削除

### DIFF
--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,6 +1,4 @@
 export type Severity = "Critical" | "High" | "Medium" | "Low";
-export type Status = "analyzing" | "completed" | "failed";
-export type Role = "Admin" | "Editor" | "Viewer";
 
 export interface Vulnerability {
   id: string;
@@ -20,7 +18,7 @@ export interface Member {
   id: string;
   name: string;
   email: string;
-  role: Role;
+  role: "Admin" | "Editor" | "Viewer";
   avatarUrl?: string;
 }
 
@@ -30,7 +28,7 @@ export interface Project {
   name: string;
   fileName: string;
   uploadDate: Date;
-  status: Status;
+  status: "analyzing" | "completed" | "failed";
   vulnerabilities: Vulnerability[];
   pkgCount: number;
   errorMessage?: string;


### PR DESCRIPTION
## 概要

どこからも import されていない型 [Status](cci:2://file:///home/yuki/workspace/next-vuln-report-portfolio/app/types/index.ts:1:0-1:58), [Role](cci:2://file:///home/yuki/workspace/next-vuln-report-portfolio/app/types/index.ts:2:0-2:49) を削除しました。

## 変更内容

- `type Status` を削除 → `Project.status` にインライン化
- `type Role` を削除 → `Member.role` にインライン化

## 理由

未使用の型定義を整理し、必要な場所にインラインで記述するほうがシンプル。