### PR TITLE
refactor: 残りの interface → type に変更

### DIFF
--- a/app/UploadArea.tsx
+++ b/app/UploadArea.tsx
@@ -2,9 +2,9 @@ import React, { useState, useRef } from "react";
 import { Paper, Box, Typography, Button } from "@mui/material";
 import { UploadCloud } from "lucide-react";
 
-interface UploadAreaProps {
+type UploadAreaProps = {
   onUpload: (file: File) => void;
-}
+};
 
 export const UploadArea = ({ onUpload }: UploadAreaProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);

--- a/app/contexts/AppContext.tsx
+++ b/app/contexts/AppContext.tsx
@@ -11,7 +11,7 @@ import type { Team, Project } from "../types";
 import { generateMockVulnerabilities } from "../lib/mockData";
 
 // Context の型定義
-interface AppContextType {
+type AppContextType = {
   // チーム関連
   teams: Team[];
   setTeams: React.Dispatch<React.SetStateAction<Team[]>>;
@@ -32,7 +32,7 @@ interface AppContextType {
     event?: React.SyntheticEvent | Event,
     reason?: string
   ) => void;
-}
+};
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
 

--- a/app/projects/ProjectCard.tsx
+++ b/app/projects/ProjectCard.tsx
@@ -22,11 +22,11 @@ import {
 } from "lucide-react";
 import type { Project } from "../types";
 
-interface ProjectCardProps {
+type ProjectCardProps = {
   project: Project;
   onClick: () => void;
   onMenuClick: (e: React.MouseEvent, project: Project) => void;
-}
+};
 
 export const ProjectCard = ({
   project,

--- a/app/settings/TeamSettings.tsx
+++ b/app/settings/TeamSettings.tsx
@@ -23,11 +23,11 @@ import { Settings, Users, Key, Trash2, Mail, XCircle } from "lucide-react";
 import type { Team, Member } from "../types";
 import { generateMockMembers } from "../lib/mockData";
 
-interface TeamSettingsProps {
+type TeamSettingsProps = {
   team: Team;
   onUpdateTeamName: (name: string) => void;
   onDeleteTeam: () => void;
-}
+};
 
 export const TeamSettings = ({
   team,


### PR DESCRIPTION
## 概要

残りの `interface` を `type` に変更しました（コーディングルール準拠）。

## 変更内容

| ファイル | 変更 |
|---------|------|
| [TeamSettings.tsx](cci:7://file:///home/yuki/workspace/next-vuln-report-portfolio/app/settings/TeamSettings.tsx:0:0-0:0) | `interface TeamSettingsProps` → `type` |
| [ProjectCard.tsx](cci:7://file:///home/yuki/workspace/next-vuln-report-portfolio/app/projects/ProjectCard.tsx:0:0-0:0) | `interface ProjectCardProps` → `type` |
| [UploadArea.tsx](cci:7://file:///home/yuki/workspace/next-vuln-report-portfolio/app/UploadArea.tsx:0:0-0:0) | `interface UploadAreaProps` → `type` |
| [AppContext.tsx](cci:7://file:///home/yuki/workspace/next-vuln-report-portfolio/app/contexts/AppContext.tsx:0:0-0:0) | `interface AppContextType` → `type` |

## 差分

4 files changed, 8 insertions(+), 8 deletions(-)