### PR TITLE
refactor: 不要な型注釈を削除（型推論を活用）

### DIFF
--- a/app/contexts/AppContext.tsx
+++ b/app/contexts/AppContext.tsx
@@ -50,7 +50,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       name: `Project Team ${i + 6}`,
     })),
   ]);
-  const [currentTeamId, setCurrentTeamId] = useState<string>("team-1");
+  const [currentTeamId, setCurrentTeamId] = useState("team-1");
 
   // プロジェクト状態
   const [projects, setProjects] = useState<Project[]>([]);


### PR DESCRIPTION
## 概要
型推論で十分な箇所から不要な型注釈を削除しました（コーディングルール準拠）。
## 変更内容
```tsx
// Before
const [currentTeamId, setCurrentTeamId] = useState<string>("team-1");
// After
const [currentTeamId, setCurrentTeamId] = useState("team-1");
```
## 理由
初期値 "team-1" から TypeScript が string と推論できるため、明示的な型注釈は不要。