### PR TITLE
feat: integrate project list with Prisma database

### DIFF
--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -1,0 +1,84 @@
+import { prisma } from "@/lib/prisma";
+import type { Project, Vulnerability, Severity } from "@/app/types";
+import { Prisma } from "../../generated/prisma/client";
+
+// 重要度文字列をUIの型に変換
+const mapSeverity = (severity: string): Severity => {
+  switch (severity.toLowerCase()) {
+    case "critical":
+      return "Critical";
+    case "high":
+      return "High";
+    case "medium":
+      return "Medium";
+    case "low":
+    default:
+      return "Low";
+  }
+};
+
+type ProjectWithPackages = Prisma.ProjectGetPayload<{
+  include: {
+    packages: {
+      include: {
+        vulnerability: true;
+      };
+    };
+  };
+}>;
+
+export async function getProjects(teamId?: string): Promise<Project[]> {
+  const where = teamId ? { teamId } : {};
+  const projects = await prisma.project.findMany({
+    where,
+    include: {
+      packages: {
+        include: {
+          vulnerability: true,
+        },
+      },
+    },
+    orderBy: {
+      uploadDate: "desc",
+    },
+  });
+
+  return projects.map((p: ProjectWithPackages) => convertToUIProject(p));
+}
+
+function convertToUIProject(p: ProjectWithPackages): Project {
+  // Project -> Package -> Vulnerability の構造をフラットな Vulnerability 配列に変換
+  const vulnerabilities: Vulnerability[] = p.packages
+    .filter((pkg) => pkg.vulnerability) // 脆弱性があるパッケージのみ
+    .map((pkg) => {
+      const v = pkg.vulnerability!;
+      return {
+        id: v.id,
+        packageName: pkg.name,
+        version: pkg.version,
+        severity: mapSeverity(v.severity),
+        cve: v.cve || "N/A",
+        description: v.description,
+      };
+    });
+
+  return {
+    id: p.id,
+    teamId: p.teamId,
+    name: p.name,
+    fileName: p.fileName,
+    uploadDate: p.uploadDate,
+    status: p.status as "analyzing" | "completed" | "failed",
+    vulnerabilities: vulnerabilities,
+    pkgCount: p.pkgCount,
+    errorMessage: p.errorMessage || undefined,
+  };
+}
+
+export async function getTeams() {
+  return await prisma.team.findMany({
+    orderBy: {
+      createdAt: "asc",
+    },
+  });
+}

--- a/app/projects/ProjectListView.tsx
+++ b/app/projects/ProjectListView.tsx
@@ -23,17 +23,33 @@ import {
 import { Search, Settings, UploadCloud, Edit2, Trash2 } from "lucide-react";
 import { useApp } from "../contexts/AppContext";
 import { ProjectCard } from "./ProjectCard";
-import type { Project } from "../types";
+import type { Project, Team } from "../types";
 
-export const ProjectListView = () => {
+type Props = {
+  initialProjects?: Project[];
+  initialTeams?: Team[];
+};
+
+export const ProjectListView = ({ initialProjects, initialTeams }: Props) => {
   const router = useRouter();
   const {
     currentTeam,
     filteredProjects,
     projects,
     setProjects,
+    setTeams,
     showNotification,
   } = useApp();
+
+  // DBからの初期データをContextに反映
+  React.useEffect(() => {
+    if (initialTeams && initialTeams.length > 0) {
+      setTeams(initialTeams);
+    }
+    if (initialProjects) {
+      setProjects(initialProjects);
+    }
+  }, [initialTeams, initialProjects, setTeams, setProjects]);
 
   // プロジェクトメニュー
   const [projectMenuAnchor, setProjectMenuAnchor] =

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,5 +1,9 @@
 import { ProjectListView } from "./ProjectListView";
+import { getProjects, getTeams } from "../lib/data";
 
-export default function ProjectsPage() {
-  return <ProjectListView />;
+export default async function ProjectsPage() {
+  const projects = await getProjects();
+  const teams = await getTeams();
+
+  return <ProjectListView initialProjects={projects} initialTeams={teams} />;
 }


### PR DESCRIPTION
## 概要
プロジェクト一覧画面をモックデータから Prisma (SQLite) 連携に変更しました。

## 変更点
- `app/lib/data.ts`: DBデータ取得・型変換ロジックの実装
- `app/projects/page.tsx`: Server Component 化し、データをサーバーサイドで取得
- `app/projects/ProjectListView.tsx`: `initialProjects`, `initialTeams` Props を受け取れるように修正
- `.gitignore`: `generated` ディレクトリを除外設定に追加

## 確認方法
`npm run db:reset` 後、プロジェクト一覧画面でDB内のデータが表示されることを確認。