### PR TITLE
refactor: optimize project list layout and server components

### DIFF
--- a/app/components/AppHeader.tsx
+++ b/app/components/AppHeader.tsx
@@ -1,262 +1,77 @@
-"use client";
+import React from "react";
+import Link from "next/link";
+import { AppBar, Toolbar, Typography, Button, Box } from "@mui/material";
+import { ShieldAlert, UploadCloud } from "lucide-react";
+import { getTeams } from "../lib/data";
 
-import React, { useState } from "react";
-import { useRouter, usePathname } from "next/navigation";
-import {
-  AppBar,
-  Toolbar,
-  Typography,
-  Button,
-  Menu,
-  MenuItem,
-  Divider,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
-  ListItemIcon,
-  ListItemText,
-  InputAdornment,
-  Box,
-} from "@mui/material";
-import {
-  UploadCloud,
-  ShieldAlert,
-  Search,
-  Users,
-  ChevronDown,
-  Plus,
-  Settings,
-  CheckCircle,
-} from "lucide-react";
-import { useApp } from "../contexts/AppContext";
-
-export const AppHeader = () => {
-  const router = useRouter();
-  const pathname = usePathname();
-  const {
-    teams,
-    setTeams,
-    currentTeamId,
-    setCurrentTeamId,
-    currentTeam,
-    showNotification,
-  } = useApp();
-
-  const [teamMenuAnchor, setTeamMenuAnchor] = useState<null | HTMLElement>(
-    null
-  );
-  const [teamSearchQuery, setTeamSearchQuery] = useState("");
-  const [isCreateTeamOpen, setIsCreateTeamOpen] = useState(false);
-  const [newTeamName, setNewTeamName] = useState("");
-
-  const filteredTeams = teams.filter((t) =>
-    t.name.toLowerCase().includes(teamSearchQuery.toLowerCase())
-  );
-
-  const handleSwitchTeam = (teamId: string) => {
-    setCurrentTeamId(teamId);
-    setTeamMenuAnchor(null);
-    router.push("/projects");
-    showNotification(
-      `チームを「${teams.find((t) => t.id === teamId)?.name}」に切り替えました`
-    );
-  };
-
-  const handleCreateTeamSubmit = () => {
-    if (!newTeamName.trim()) return;
-    const newTeam = { id: `team-${Date.now()}`, name: newTeamName };
-    setTeams([newTeam, ...teams]);
-    setCurrentTeamId(newTeam.id);
-    setIsCreateTeamOpen(false);
-    setNewTeamName("");
-    showNotification(`新しいチーム「${newTeamName}」を作成しました`);
-  };
+export const AppHeader = async () => {
+  const teams = await getTeams();
+  const currentTeam = teams.length > 0 ? teams[0] : { name: "Unknown" };
 
   return (
-    <>
-      <AppBar
-        position="static"
-        color="default"
-        elevation={0}
-        sx={{ borderBottom: 1, borderColor: "divider", bgcolor: "white" }}
-      >
-        <Toolbar>
-          {/* チーム選択ボタン */}
-          <Button
-            onClick={(e) => {
-              setTeamMenuAnchor(e.currentTarget as HTMLElement);
-              setTeamSearchQuery("");
-            }}
-            startIcon={
-              <Box
-                sx={{
-                  bgcolor: "primary.main",
-                  color: "white",
-                  p: 0.5,
-                  borderRadius: 1,
-                  display: "flex",
-                }}
-              >
-                <ShieldAlert size={18} />
-              </Box>
-            }
-            endIcon={<ChevronDown size={16} className="text-gray-400" />}
-            sx={{
-              mr: 2,
-              textTransform: "none",
-              color: "text.primary",
-              fontWeight: "bold",
-              fontSize: "1rem",
-              maxWidth: 300,
-            }}
-          >
-            <Box sx={{ textAlign: "left", overflow: "hidden" }}>
-              <Typography
-                variant="caption"
-                display="block"
-                color="text.secondary"
-                lineHeight={1}
-              >
-                Team
-              </Typography>
-              <Typography noWrap>{currentTeam.name}</Typography>
-            </Box>
-          </Button>
-
-          {/* チームメニュー */}
-          <Menu
-            anchorEl={teamMenuAnchor}
-            open={Boolean(teamMenuAnchor)}
-            onClose={() => setTeamMenuAnchor(null)}
-            PaperProps={{ sx: { width: 320, mt: 1, maxHeight: 500 } }}
-          >
+    <AppBar
+      position="static"
+      color="default"
+      elevation={0}
+      sx={{ borderBottom: 1, borderColor: "divider", bgcolor: "white" }}
+    >
+      <Toolbar>
+        {/* チーム表示 (現在固定) */}
+        <Button
+          startIcon={
             <Box
               sx={{
-                px: 2,
-                py: 1,
-                position: "sticky",
-                top: 0,
-                bgcolor: "white",
-                zIndex: 1,
+                bgcolor: "primary.main",
+                color: "white",
+                p: 0.5,
+                borderRadius: 1,
+                display: "flex",
               }}
             >
-              <TextField
-                size="small"
-                fullWidth
-                placeholder="Search..."
-                value={teamSearchQuery}
-                onChange={(e) => setTeamSearchQuery(e.target.value)}
-                onKeyDown={(e) => e.stopPropagation()}
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <Search size={16} className="text-gray-400" />
-                    </InputAdornment>
-                  ),
-                }}
-              />
+              <ShieldAlert size={18} />
             </Box>
-            <Divider />
-            <Box sx={{ maxHeight: 300, overflowY: "auto" }}>
-              {filteredTeams.map((t) => (
-                <MenuItem
-                  key={t.id}
-                  selected={t.id === currentTeamId}
-                  onClick={() => handleSwitchTeam(t.id)}
-                >
-                  <ListItemIcon>
-                    <Users size={18} />
-                  </ListItemIcon>
-                  <ListItemText primary={t.name} />
-                  {t.id === currentTeamId && (
-                    <CheckCircle size={16} className="text-blue-500" />
-                  )}
-                </MenuItem>
-              ))}
-            </Box>
-            <Divider sx={{ my: 1 }} />
-            <MenuItem
-              onClick={() => {
-                setTeamMenuAnchor(null);
-                setIsCreateTeamOpen(true);
-                setNewTeamName("");
-              }}
-              sx={{ color: "primary.main" }}
+          }
+          sx={{
+            mr: 2,
+            textTransform: "none",
+            color: "text.primary",
+            fontWeight: "bold",
+            fontSize: "1rem",
+            maxWidth: 300,
+          }}
+        >
+          <Box sx={{ textAlign: "left", overflow: "hidden" }}>
+            <Typography
+              variant="caption"
+              display="block"
+              color="text.secondary"
+              lineHeight={1}
             >
-              <ListItemIcon>
-                <Plus size={18} color="#1976d2" />
-              </ListItemIcon>
-              <ListItemText primary="新しいチームを作成" />
-            </MenuItem>
-            <Divider sx={{ my: 1 }} />
-            <MenuItem
-              onClick={() => {
-                router.push("/settings");
-                setTeamMenuAnchor(null);
-              }}
-            >
-              <ListItemIcon>
-                <Settings size={18} />
-              </ListItemIcon>
-              <ListItemText primary="チーム設定" />
-            </MenuItem>
-          </Menu>
+              Team
+            </Typography>
+            <Typography noWrap>{currentTeam.name}</Typography>
+          </Box>
+        </Button>
 
-          <Box sx={{ flexGrow: 1 }} />
+        <Box sx={{ flexGrow: 1 }} />
 
-          {/* ナビゲーションボタン */}
-          <Button
-            color="inherit"
-            onClick={() => router.push("/projects")}
-            sx={{ fontWeight: pathname === "/projects" ? "bold" : "normal" }}
-          >
+        {/* ナビゲーション */}
+        <Link href="/projects" style={{ textDecoration: "none" }}>
+          <Button color="inherit" sx={{ mr: 2 }}>
             プロジェクト一覧
           </Button>
+        </Link>
+
+        <Link href="/" style={{ textDecoration: "none" }}>
           <Button
             variant="contained"
             startIcon={<UploadCloud size={18} />}
-            onClick={() => router.push("/")}
             disableElevation
-            sx={{ ml: 2 }}
           >
             新規アップロード
           </Button>
-        </Toolbar>
-      </AppBar>
-
-      {/* チーム作成ダイアログ */}
-      <Dialog
-        open={isCreateTeamOpen}
-        onClose={() => setIsCreateTeamOpen(false)}
-        fullWidth
-        maxWidth="xs"
-      >
-        <DialogTitle>新しいチームを作成</DialogTitle>
-        <DialogContent>
-          <TextField
-            autoFocus
-            margin="dense"
-            label="チーム名"
-            fullWidth
-            variant="outlined"
-            value={newTeamName}
-            onChange={(e) => setNewTeamName(e.target.value)}
-            placeholder="例: Security Team, Frontend Squad"
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setIsCreateTeamOpen(false)}>キャンセル</Button>
-          <Button
-            onClick={handleCreateTeamSubmit}
-            variant="contained"
-            disabled={!newTeamName.trim()}
-          >
-            作成
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </>
+        </Link>
+      </Toolbar>
+    </AppBar>
   );
 };

--- a/app/projects/HeaderActions.tsx
+++ b/app/projects/HeaderActions.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+import { Box, Button } from "@mui/material";
+import { Search, Settings } from "lucide-react";
+
+export const HeaderActions = () => {
+  const router = useRouter();
+
+  return (
+    <Box sx={{ display: "flex", gap: 1 }}>
+      <Button startIcon={<Search size={18} />} color="inherit">
+        検索
+      </Button>
+      <Button
+        startIcon={<Settings size={18} />}
+        color="inherit"
+        onClick={() => router.push("/settings")}
+      >
+        設定
+      </Button>
+    </Box>
+  );
+};

--- a/app/projects/ProjectCard.tsx
+++ b/app/projects/ProjectCard.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Card,
   CardContent,
@@ -6,7 +5,6 @@ import {
   Chip,
   Typography,
   Box,
-  IconButton,
   Skeleton,
   LinearProgress,
   Stack,
@@ -18,21 +16,15 @@ import {
   XCircle,
   ShieldAlert,
   AlertCircle,
-  MoreVertical,
 } from "lucide-react";
 import type { Project } from "../types";
+import { ProjectMenu } from "./ProjectMenu";
 
-type ProjectCardProps = {
+type Props = {
   project: Project;
-  onClick: () => void;
-  onMenuClick: (e: React.MouseEvent, project: Project) => void;
 };
 
-export const ProjectCard = ({
-  project,
-  onClick,
-  onMenuClick,
-}: ProjectCardProps) => {
+export const ProjectCard = ({ project }: Props) => {
   const isAnalyzing = project.status === "analyzing";
   const isFailed = project.status === "failed";
 
@@ -55,23 +47,21 @@ export const ProjectCard = ({
         },
       }}
     >
-      <IconButton
-        size="small"
-        onClick={(e) => onMenuClick(e, project)}
+      <Box
         sx={{
           position: "absolute",
           top: 8,
           right: 8,
           zIndex: 10,
           bgcolor: "rgba(255,255,255,0.8)",
+          borderRadius: "50%",
           "&:hover": { bgcolor: "white" },
         }}
       >
-        <MoreVertical size={18} />
-      </IconButton>
+        <ProjectMenu project={project} />
+      </Box>
 
       <CardActionArea
-        onClick={onClick}
         disabled={isAnalyzing || isFailed}
         sx={{
           height: "100%",

--- a/app/projects/ProjectMenu.tsx
+++ b/app/projects/ProjectMenu.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  IconButton,
+} from "@mui/material";
+import { MoreVertical, Edit2, Trash2 } from "lucide-react";
+import { useApp } from "../contexts/AppContext";
+import type { Project } from "../types";
+
+type Props = {
+  project: Project;
+};
+
+export const ProjectMenu = ({ project }: Props) => {
+  const { showNotification } = useApp();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+
+  const handleMenuClick = (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault(); // Link遷移を防ぐ
+    event.stopPropagation();
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleRenameClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setNewName(project.name);
+    setIsRenameDialogOpen(true);
+    handleClose();
+  };
+
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    // TODO: Server Action
+    showNotification(`「${project.name}」を削除しました（モック）`);
+    handleClose();
+  };
+
+  const handleRenameSubmit = () => {
+    if (newName.trim()) {
+      // TODO: Server Action (optimistic update or revalidate)
+      showNotification(`名前を「${newName}」に変更しました（モック）`);
+      setIsRenameDialogOpen(false);
+    }
+  };
+
+  // ダイアログクリック時の伝播防止
+  const handleDialogClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+  };
+
+  return (
+    <>
+      <IconButton
+        size="small"
+        onClick={handleMenuClick}
+        sx={{ color: "text.secondary" }}
+      >
+        <MoreVertical size={20} />
+      </IconButton>
+
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+        <MenuItem onClick={handleRenameClick}>
+          <ListItemIcon>
+            <Edit2 size={16} />
+          </ListItemIcon>
+          <ListItemText primary="名前を変更" />
+        </MenuItem>
+        <MenuItem onClick={handleDeleteClick} sx={{ color: "error.main" }}>
+          <ListItemIcon>
+            <Trash2 size={16} color="#d32f2f" />
+          </ListItemIcon>
+          <ListItemText primary="削除" />
+        </MenuItem>
+      </Menu>
+
+      {/* onClick, onMouseDownで伝播を止める */}
+      <div onClick={handleDialogClick} onMouseDown={handleDialogClick}>
+        <Dialog
+          open={isRenameDialogOpen}
+          onClose={() => setIsRenameDialogOpen(false)}
+        >
+          <DialogTitle>プロジェクト名を変更</DialogTitle>
+          <DialogContent sx={{ pt: 1 }}>
+            <TextField
+              autoFocus
+              margin="dense"
+              label="プロジェクト名"
+              fullWidth
+              variant="outlined"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setIsRenameDialogOpen(false)}>
+              キャンセル
+            </Button>
+            <Button onClick={handleRenameSubmit} variant="contained">
+              保存
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    </>
+  );
+};

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,9 +1,5 @@
 import { ProjectListView } from "./ProjectListView";
-import { getProjects, getTeams } from "../lib/data";
 
-export default async function ProjectsPage() {
-  const projects = await getProjects();
-  const teams = await getTeams();
-
-  return <ProjectListView initialProjects={projects} initialTeams={teams} />;
+export default function ProjectsPage() {
+  return <ProjectListView />;
 }


### PR DESCRIPTION
## 概要
プロジェクト一覧画面とヘッダーのリファクタリングを行いました。
Server Component を活用し、クライアントコンポーネントを最小限に切り出すことで、Props のバケツリレーや Context への依存を排除しました。

## 主な変更点
- **AppHeader**: Server Component 化。DBからチーム名を取得して表示（チーム切り替え機能は一時的にRead-only化）。
- **ProjectListView**: Server Component 化。リスト表示ロジックを集約。
- **HeaderActions**: ヘッダーのボタン部分のみを Client Component として切り出し。
- **ProjectMenu**: プロジェクト操作メニューを Client Component として切り出し、`ProjectCard` に埋め込み。
- **ProjectCard**: `action` prop を廃止し、内部で `ProjectMenu` を利用するように変更。
- **不要ファイルの削除**: `ProjectGrid`, `ProjectListHeader`, `EmptyProjectState`, `InitAppContext` などを整理・統合。

## 目的
- DBデータ連携の効率化（Server Fetching）
- クライアントバンドルサイズの削減
- コンポーネント構成のシンプル化