### PR TITLE
feat: プロジェクト詳細画面のSSR化

### DIFF
--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -75,6 +75,23 @@ function convertToUIProject(p: ProjectWithPackages): Project {
   };
 }
 
+// 単一プロジェクトを ID で取得
+export async function getProjectById(id: string): Promise<Project | null> {
+  const project = await prisma.project.findUnique({
+    where: { id },
+    include: {
+      packages: {
+        include: {
+          vulnerability: true,
+        },
+      },
+    },
+  });
+
+  if (!project) return null;
+  return convertToUIProject(project);
+}
+
 export async function getTeams() {
   return await prisma.team.findMany({
     orderBy: {

--- a/app/projects/[id]/ProjectDetailView.tsx
+++ b/app/projects/[id]/ProjectDetailView.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useMemo } from "react";
 import Link from "next/link";
-import { useParams } from "next/navigation";
 import {
   Box,
   Container,
@@ -38,19 +37,19 @@ import {
   Filter,
   ArrowUpDown,
 } from "lucide-react";
-import { useApp } from "../../contexts/AppContext";
 import { SeverityChip } from "./SeverityChip";
 import { callGeminiAPI } from "../../lib/gemini";
-import type { Vulnerability, Severity } from "../../types";
+import type { Project, Team, Vulnerability, Severity } from "../../types";
 
-export const ProjectDetailView = () => {
-  const params = useParams();
-  const projectId = params.id as string;
-  const { projects, currentTeam } = useApp();
+type ProjectDetailViewProps = {
+  project: Project;
+  currentTeam: Team;
+};
 
-  // プロジェクトを取得
-  const project = projects.find((p) => p.id === projectId);
-
+export const ProjectDetailView = ({
+  project,
+  currentTeam,
+}: ProjectDetailViewProps) => {
   // フィルタ・ソート状態
   const [vulnSearchQuery, setVulnSearchQuery] = useState("");
   const [severityFilter, setSeverityFilter] = useState<Severity | "All">("All");
@@ -66,7 +65,6 @@ export const ProjectDetailView = () => {
 
   // フィルタリング済み脆弱性
   const filteredVulnerabilities = useMemo(() => {
-    if (!project) return [];
     let vulns = [...project.vulnerabilities];
     if (severityFilter !== "All")
       vulns = vulns.filter((v) => v.severity === severityFilter);
@@ -85,7 +83,7 @@ export const ProjectDetailView = () => {
         : a.packageName.localeCompare(b.packageName)
     );
     return vulns;
-  }, [project, severityFilter, vulnSearchQuery, sortOrder]);
+  }, [project.vulnerabilities, severityFilter, vulnSearchQuery, sortOrder]);
 
   // AI 解説
   const handleAiRemediation = async (vuln: Vulnerability) => {
@@ -107,7 +105,6 @@ export const ProjectDetailView = () => {
 
   // プロジェクト全体レポート
   const handleAiProjectReport = async () => {
-    if (!project) return;
     setAiContext(`プロジェクト分析レポート: ${project.name}`);
     setAiResult("");
     setAiDialogOpen(true);
@@ -121,20 +118,6 @@ export const ProjectDetailView = () => {
       setAiLoading(false);
     }
   };
-
-  // プロジェクトが見つからない場合
-  if (!project) {
-    return (
-      <Box sx={{ minHeight: "100vh", bgcolor: "grey.50", pb: 8 }}>
-        <Container maxWidth="lg" sx={{ mt: 4 }}>
-          <Typography variant="h5">プロジェクトが見つかりません</Typography>
-          <Link href="/projects" style={{ textDecoration: "none" }}>
-            <Button sx={{ mt: 2 }}>プロジェクト一覧に戻る</Button>
-          </Link>
-        </Container>
-      </Box>
-    );
-  }
 
   return (
     <Box sx={{ minHeight: "100vh", bgcolor: "grey.50", pb: 8 }}>

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,5 +1,22 @@
+import { notFound } from "next/navigation";
+import { getProjectById, getTeams } from "@/app/lib/data";
 import { ProjectDetailView } from "./ProjectDetailView";
 
-export default function ProjectDetailPage() {
-  return <ProjectDetailView />;
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function ProjectDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const [project, teams] = await Promise.all([getProjectById(id), getTeams()]);
+
+  if (!project) {
+    notFound();
+  }
+
+  // TODO: チーム選択は URL/Cookie で管理すべき。ここでは先頭チームを仮で使用
+  const currentTeam = teams.find((t) => t.id === project.teamId) ??
+    teams[0] ?? { id: "", name: "Unknown" };
+
+  return <ProjectDetailView project={project} currentTeam={currentTeam} />;
 }


### PR DESCRIPTION
## 概要
プロジェクト詳細画面（`/projects/[id]`）をServer Component化し、Prisma DBから直接データを取得するようにリファクタリングしました。

## 変更内容
- **データ取得ロジックの追加**: `app/lib/data.ts` に `getProjectById` を追加しました。
- **Server Component化**: `app/projects/[id]/page.tsx` を `async` コンポーネントにし、サーバーサイドでデータをフェッチするようにしました。
- **Viewコンポーネントのリファクタリング**: `ProjectDetailView.tsx` から `AppContext` (`useApp`) と `useParams` への依存を排除し、Propsでデータを受け取るように変更しました。
- **エラーハンドリング**: プロジェクトが見つからない場合に `notFound()` を呼び出すようにしました。

## 影響範囲
- プロジェクト詳細画面のデータ取得フローがDB直結になりました。
- `AppContext` 内のモックデータへの依存がさらに減少しました。