### PR TITLE
refactor: ProjectDetailView のコンポーネント分離

### DIFF
--- a/app/projects/[id]/AiReportButton.tsx
+++ b/app/projects/[id]/AiReportButton.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Box,
+  Typography,
+  Paper,
+  CircularProgress,
+} from "@mui/material";
+import { Sparkles } from "lucide-react";
+import { callGeminiAPI } from "../../lib/gemini";
+
+export const AiReportButton = ({ projectName }: { projectName: string }) => {
+  const [aiDialogOpen, setAiDialogOpen] = useState(false);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiResult, setAiResult] = useState("");
+
+  const handleAiProjectReport = async () => {
+    setAiResult("");
+    setAiDialogOpen(true);
+    setAiLoading(true);
+    try {
+      const result = await callGeminiAPI(`Project Analysis: ${projectName}`);
+      setAiResult(result);
+    } catch {
+      setAiResult("Error");
+    } finally {
+      setAiLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        color="secondary"
+        startIcon={<Sparkles size={16} />}
+        onClick={handleAiProjectReport}
+        sx={{
+          bgcolor: "secondary.main",
+          color: "white",
+          fontWeight: "bold",
+          boxShadow: 2,
+        }}
+      >
+        AIリスク分析
+      </Button>
+
+      <Dialog
+        open={aiDialogOpen}
+        onClose={() => setAiDialogOpen(false)}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            bgcolor: "secondary.50",
+            color: "secondary.main",
+          }}
+        >
+          <Sparkles size={20} />
+          <Typography variant="h6" component="div" fontWeight="bold">
+            Gemini AI Analysis
+          </Typography>
+        </DialogTitle>
+        <DialogContent sx={{ minHeight: 300, p: 4 }}>
+          <Typography
+            variant="subtitle2"
+            color="text.secondary"
+            gutterBottom
+            sx={{ mb: 2 }}
+          >
+            プロジェクト分析レポート: {projectName}
+          </Typography>
+          {aiLoading ? (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                height: 200,
+                gap: 2,
+              }}
+            >
+              <CircularProgress color="secondary" />
+              <Typography color="text.secondary" className="animate-pulse">
+                AIが分析中...
+              </Typography>
+            </Box>
+          ) : (
+            <Paper
+              variant="outlined"
+              sx={{
+                p: 3,
+                bgcolor: "grey.50",
+                whiteSpace: "pre-line",
+                lineHeight: 1.6,
+              }}
+            >
+              {aiResult.split("\n").map((l, i) => (
+                <Typography key={i} paragraph sx={{ mb: 1 }}>
+                  {l.startsWith("**") ? (
+                    <Box component="span" fontWeight="bold">
+                      {l.replace(/\*\*/g, "")}
+                    </Box>
+                  ) : (
+                    l
+                  )}
+                </Typography>
+              ))}
+            </Paper>
+          )}
+        </DialogContent>
+        <DialogActions sx={{ p: 2 }}>
+          <Button onClick={() => setAiDialogOpen(false)} color="inherit">
+            閉じる
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={() => setAiDialogOpen(false)}
+          >
+            理解しました
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};

--- a/app/projects/[id]/ProjectDetailView.tsx
+++ b/app/projects/[id]/ProjectDetailView.tsx
@@ -1,123 +1,39 @@
-"use client";
-
-import React, { useState, useMemo } from "react";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import {
   Box,
   Container,
   Typography,
-  Button,
   Grid,
   Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
   Divider,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
-  InputAdornment,
   Breadcrumbs,
   Stack,
   Chip,
-  CircularProgress,
 } from "@mui/material";
-import {
-  FileCode,
-  Search,
-  ChevronRight,
-  Home,
-  Sparkles,
-  Bot,
-  Filter,
-  ArrowUpDown,
-} from "lucide-react";
-import { SeverityChip } from "./SeverityChip";
-import { callGeminiAPI } from "../../lib/gemini";
-import type { Project, Team, Vulnerability, Severity } from "../../types";
+import { FileCode, ChevronRight, Home } from "lucide-react";
+import { getProjectById, getTeams } from "@/app/lib/data";
+import { VulnerabilitySection } from "./VulnerabilitySection";
+import { AiReportButton } from "./AiReportButton";
 
-type ProjectDetailViewProps = {
-  project: Project;
-  currentTeam: Team;
-};
+export const ProjectDetailView = async ({
+  projectId,
+}: {
+  projectId: string;
+}) => {
+  // データ取得
+  const [project, teams] = await Promise.all([
+    getProjectById(projectId),
+    getTeams(),
+  ]);
 
-export const ProjectDetailView = ({
-  project,
-  currentTeam,
-}: ProjectDetailViewProps) => {
-  // フィルタ・ソート状態
-  const [vulnSearchQuery, setVulnSearchQuery] = useState("");
-  const [severityFilter, setSeverityFilter] = useState<Severity | "All">("All");
-  const [sortOrder, setSortOrder] = useState<"severity" | "package">(
-    "severity"
-  );
+  if (!project) {
+    notFound();
+  }
 
-  // AI ダイアログ状態
-  const [aiDialogOpen, setAiDialogOpen] = useState(false);
-  const [aiLoading, setAiLoading] = useState(false);
-  const [aiResult, setAiResult] = useState("");
-  const [aiContext, setAiContext] = useState("");
-
-  // フィルタリング済み脆弱性
-  const filteredVulnerabilities = useMemo(() => {
-    let vulns = [...project.vulnerabilities];
-    if (severityFilter !== "All")
-      vulns = vulns.filter((v) => v.severity === severityFilter);
-    if (vulnSearchQuery) {
-      const q = vulnSearchQuery.toLowerCase();
-      vulns = vulns.filter(
-        (v) =>
-          v.packageName.toLowerCase().includes(q) ||
-          v.cve.toLowerCase().includes(q)
-      );
-    }
-    vulns.sort((a, b) =>
-      sortOrder === "severity"
-        ? ["Critical", "High", "Medium", "Low"].indexOf(a.severity) -
-          ["Critical", "High", "Medium", "Low"].indexOf(b.severity)
-        : a.packageName.localeCompare(b.packageName)
-    );
-    return vulns;
-  }, [project.vulnerabilities, severityFilter, vulnSearchQuery, sortOrder]);
-
-  // AI 解説
-  const handleAiRemediation = async (vuln: Vulnerability) => {
-    setAiContext(`脆弱性分析: ${vuln.packageName} (${vuln.cve})`);
-    setAiResult("");
-    setAiDialogOpen(true);
-    setAiLoading(true);
-    try {
-      const result = await callGeminiAPI(
-        `脆弱性解説: ${vuln.packageName} ${vuln.cve}`
-      );
-      setAiResult(result);
-    } catch {
-      setAiResult("Error");
-    } finally {
-      setAiLoading(false);
-    }
-  };
-
-  // プロジェクト全体レポート
-  const handleAiProjectReport = async () => {
-    setAiContext(`プロジェクト分析レポート: ${project.name}`);
-    setAiResult("");
-    setAiDialogOpen(true);
-    setAiLoading(true);
-    try {
-      const result = await callGeminiAPI(`Project Analysis: ${project.name}`);
-      setAiResult(result);
-    } catch {
-      setAiResult("Error");
-    } finally {
-      setAiLoading(false);
-    }
-  };
+  // TODO: チーム選択は URL/Cookie で管理すべき
+  const currentTeam = teams.find((t) => t.id === project.teamId) ??
+    teams[0] ?? { id: "", name: "Unknown" };
 
   return (
     <Box sx={{ minHeight: "100vh", bgcolor: "grey.50", pb: 8 }}>
@@ -182,20 +98,7 @@ export const ProjectDetailView = ({
             </Grid>
             <Grid>
               <Stack direction="row" spacing={2} alignItems="center">
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  startIcon={<Sparkles size={16} />}
-                  onClick={handleAiProjectReport}
-                  sx={{
-                    bgcolor: "secondary.main",
-                    color: "white",
-                    fontWeight: "bold",
-                    boxShadow: 2,
-                  }}
-                >
-                  AIリスク分析
-                </Button>
+                <AiReportButton projectName={project.name} />
                 <Divider orientation="vertical" flexItem />
                 <Chip
                   label={`${project.vulnerabilities.length} 件の脆弱性`}
@@ -208,226 +111,11 @@ export const ProjectDetailView = ({
           </Grid>
         </Paper>
 
-        {/* フィルタバー */}
-        <Box
-          sx={{
-            display: "flex",
-            flexWrap: "wrap",
-            gap: 2,
-            mb: 2,
-            alignItems: "center",
-          }}
-        >
-          <TextField
-            size="small"
-            placeholder="パッケージ名やCVEで検索..."
-            value={vulnSearchQuery}
-            onChange={(e) => setVulnSearchQuery(e.target.value)}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={16} />
-                </InputAdornment>
-              ),
-            }}
-            sx={{ minWidth: 300, bgcolor: "white" }}
-          />
-          <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
-            <Filter size={16} className="text-gray-500" />
-            <Typography variant="body2" color="text.secondary">
-              深刻度:
-            </Typography>
-            {(["All", "Critical", "High", "Medium", "Low"] as const).map(
-              (sev) => (
-                <Chip
-                  key={sev}
-                  label={sev}
-                  size="small"
-                  variant={severityFilter === sev ? "filled" : "outlined"}
-                  color={
-                    severityFilter === sev
-                      ? sev === "All"
-                        ? "default"
-                        : sev === "Critical" || sev === "High"
-                        ? "error"
-                        : sev === "Medium"
-                        ? "warning"
-                        : "info"
-                      : "default"
-                  }
-                  onClick={() => setSeverityFilter(sev)}
-                  sx={{ cursor: "pointer" }}
-                />
-              )
-            )}
-          </Box>
-          <Box sx={{ flexGrow: 1 }} />
-          <Button
-            size="small"
-            startIcon={<ArrowUpDown size={16} />}
-            onClick={() =>
-              setSortOrder((prev) =>
-                prev === "severity" ? "package" : "severity"
-              )
-            }
-          >
-            並び替え: {sortOrder === "severity" ? "深刻度順" : "パッケージ名順"}
-          </Button>
-        </Box>
-
-        {/* 脆弱性テーブル */}
-        <TableContainer component={Paper} variant="outlined">
-          <Table>
-            <TableHead sx={{ bgcolor: "grey.50" }}>
-              <TableRow>
-                <TableCell sx={{ fontWeight: "bold" }}>深刻度</TableCell>
-                <TableCell sx={{ fontWeight: "bold" }}>パッケージ</TableCell>
-                <TableCell sx={{ fontWeight: "bold" }}>バージョン</TableCell>
-                <TableCell sx={{ fontWeight: "bold" }}>CVE ID</TableCell>
-                <TableCell sx={{ fontWeight: "bold" }}>詳細</TableCell>
-                <TableCell sx={{ fontWeight: "bold", width: 140 }}>
-                  アクション
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {filteredVulnerabilities.length > 0 ? (
-                filteredVulnerabilities.map((vuln) => (
-                  <TableRow key={vuln.id} hover>
-                    <TableCell>
-                      <SeverityChip severity={vuln.severity} />
-                    </TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>
-                      {vuln.packageName}
-                    </TableCell>
-                    <TableCell>{vuln.version}</TableCell>
-                    <TableCell sx={{ fontFamily: "monospace" }}>
-                      {vuln.cve}
-                    </TableCell>
-                    <TableCell
-                      sx={{ color: "text.secondary", maxWidth: 300 }}
-                      className="truncate"
-                    >
-                      {vuln.description}
-                    </TableCell>
-                    <TableCell>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        color="secondary"
-                        startIcon={<Bot size={14} />}
-                        onClick={() => handleAiRemediation(vuln)}
-                        sx={{ textTransform: "none" }}
-                      >
-                        AI解説
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                ))
-              ) : (
-                <TableRow>
-                  <TableCell colSpan={6} align="center" sx={{ py: 8 }}>
-                    <Box
-                      sx={{
-                        display: "flex",
-                        flexDirection: "column",
-                        alignItems: "center",
-                        color: "text.secondary",
-                      }}
-                    >
-                      <Search size={40} />
-                      <Typography sx={{ mt: 1 }}>該当なし</Typography>
-                    </Box>
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
-
-        {/* AI ダイアログ */}
-        <Dialog
-          open={aiDialogOpen}
-          onClose={() => setAiDialogOpen(false)}
-          maxWidth="md"
-          fullWidth
-        >
-          <DialogTitle
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 1,
-              bgcolor: "secondary.50",
-              color: "secondary.main",
-            }}
-          >
-            <Sparkles size={20} />
-            <Typography variant="h6" component="div" fontWeight="bold">
-              Gemini AI Analysis
-            </Typography>
-          </DialogTitle>
-          <DialogContent sx={{ minHeight: 300, p: 4 }}>
-            <Typography
-              variant="subtitle2"
-              color="text.secondary"
-              gutterBottom
-              sx={{ mb: 2 }}
-            >
-              {aiContext}
-            </Typography>
-            {aiLoading ? (
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  height: 200,
-                  gap: 2,
-                }}
-              >
-                <CircularProgress color="secondary" />
-                <Typography color="text.secondary" className="animate-pulse">
-                  AIが分析中...
-                </Typography>
-              </Box>
-            ) : (
-              <Paper
-                variant="outlined"
-                sx={{
-                  p: 3,
-                  bgcolor: "grey.50",
-                  whiteSpace: "pre-line",
-                  lineHeight: 1.6,
-                }}
-              >
-                {aiResult.split("\n").map((l, i) => (
-                  <Typography key={i} paragraph sx={{ mb: 1 }}>
-                    {l.startsWith("**") ? (
-                      <Box component="span" fontWeight="bold">
-                        {l.replace(/\*\*/g, "")}
-                      </Box>
-                    ) : (
-                      l
-                    )}
-                  </Typography>
-                ))}
-              </Paper>
-            )}
-          </DialogContent>
-          <DialogActions sx={{ p: 2 }}>
-            <Button onClick={() => setAiDialogOpen(false)} color="inherit">
-              閉じる
-            </Button>
-            <Button
-              variant="contained"
-              color="secondary"
-              onClick={() => setAiDialogOpen(false)}
-            >
-              理解しました
-            </Button>
-          </DialogActions>
-        </Dialog>
+        {/* 脆弱性セクション (Client Component) */}
+        <VulnerabilitySection
+          vulnerabilities={project.vulnerabilities}
+          projectName={project.name}
+        />
       </Container>
     </Box>
   );

--- a/app/projects/[id]/VulnerabilitySection.tsx
+++ b/app/projects/[id]/VulnerabilitySection.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import {
+  Box,
+  Typography,
+  Button,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  InputAdornment,
+  Chip,
+  CircularProgress,
+} from "@mui/material";
+import { Search, Sparkles, Bot, Filter, ArrowUpDown } from "lucide-react";
+import { SeverityChip } from "./SeverityChip";
+import { callGeminiAPI } from "../../lib/gemini";
+import type { Vulnerability, Severity } from "../../types";
+
+export const VulnerabilitySection = ({
+  vulnerabilities,
+  projectName,
+}: {
+  vulnerabilities: Vulnerability[];
+  projectName: string;
+}) => {
+  // フィルタ・ソート状態
+  const [vulnSearchQuery, setVulnSearchQuery] = useState("");
+  const [severityFilter, setSeverityFilter] = useState<Severity | "All">("All");
+  const [sortOrder, setSortOrder] = useState<"severity" | "package">(
+    "severity"
+  );
+
+  // AI ダイアログ状態
+  const [aiDialogOpen, setAiDialogOpen] = useState(false);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiResult, setAiResult] = useState("");
+  const [aiContext, setAiContext] = useState("");
+
+  // フィルタリング済み脆弱性
+  const filteredVulnerabilities = useMemo(() => {
+    let vulns = [...vulnerabilities];
+    if (severityFilter !== "All")
+      vulns = vulns.filter((v) => v.severity === severityFilter);
+    if (vulnSearchQuery) {
+      const q = vulnSearchQuery.toLowerCase();
+      vulns = vulns.filter(
+        (v) =>
+          v.packageName.toLowerCase().includes(q) ||
+          v.cve.toLowerCase().includes(q)
+      );
+    }
+    vulns.sort((a, b) =>
+      sortOrder === "severity"
+        ? ["Critical", "High", "Medium", "Low"].indexOf(a.severity) -
+          ["Critical", "High", "Medium", "Low"].indexOf(b.severity)
+        : a.packageName.localeCompare(b.packageName)
+    );
+    return vulns;
+  }, [vulnerabilities, severityFilter, vulnSearchQuery, sortOrder]);
+
+  // AI 解説
+  const handleAiRemediation = async (vuln: Vulnerability) => {
+    setAiContext(`脆弱性分析: ${vuln.packageName} (${vuln.cve})`);
+    setAiResult("");
+    setAiDialogOpen(true);
+    setAiLoading(true);
+    try {
+      const result = await callGeminiAPI(
+        `脆弱性解説: ${vuln.packageName} ${vuln.cve}`
+      );
+      setAiResult(result);
+    } catch {
+      setAiResult("Error");
+    } finally {
+      setAiLoading(false);
+    }
+  };
+
+  return (
+    <>
+      {/* フィルタバー */}
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 2,
+          mb: 2,
+          alignItems: "center",
+        }}
+      >
+        <TextField
+          size="small"
+          placeholder="パッケージ名やCVEで検索..."
+          value={vulnSearchQuery}
+          onChange={(e) => setVulnSearchQuery(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Search size={16} />
+              </InputAdornment>
+            ),
+          }}
+          sx={{ minWidth: 300, bgcolor: "white" }}
+        />
+        <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+          <Filter size={16} className="text-gray-500" />
+          <Typography variant="body2" color="text.secondary">
+            深刻度:
+          </Typography>
+          {(["All", "Critical", "High", "Medium", "Low"] as const).map(
+            (sev) => (
+              <Chip
+                key={sev}
+                label={sev}
+                size="small"
+                variant={severityFilter === sev ? "filled" : "outlined"}
+                color={
+                  severityFilter === sev
+                    ? sev === "All"
+                      ? "default"
+                      : sev === "Critical" || sev === "High"
+                      ? "error"
+                      : sev === "Medium"
+                      ? "warning"
+                      : "info"
+                    : "default"
+                }
+                onClick={() => setSeverityFilter(sev)}
+                sx={{ cursor: "pointer" }}
+              />
+            )
+          )}
+        </Box>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button
+          size="small"
+          startIcon={<ArrowUpDown size={16} />}
+          onClick={() =>
+            setSortOrder((prev) =>
+              prev === "severity" ? "package" : "severity"
+            )
+          }
+        >
+          並び替え: {sortOrder === "severity" ? "深刻度順" : "パッケージ名順"}
+        </Button>
+      </Box>
+
+      {/* 脆弱性テーブル */}
+      <TableContainer component={Paper} variant="outlined">
+        <Table>
+          <TableHead sx={{ bgcolor: "grey.50" }}>
+            <TableRow>
+              <TableCell sx={{ fontWeight: "bold" }}>深刻度</TableCell>
+              <TableCell sx={{ fontWeight: "bold" }}>パッケージ</TableCell>
+              <TableCell sx={{ fontWeight: "bold" }}>バージョン</TableCell>
+              <TableCell sx={{ fontWeight: "bold" }}>CVE ID</TableCell>
+              <TableCell sx={{ fontWeight: "bold" }}>詳細</TableCell>
+              <TableCell sx={{ fontWeight: "bold", width: 140 }}>
+                アクション
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filteredVulnerabilities.length > 0 ? (
+              filteredVulnerabilities.map((vuln) => (
+                <TableRow key={vuln.id} hover>
+                  <TableCell>
+                    <SeverityChip severity={vuln.severity} />
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: 600 }}>
+                    {vuln.packageName}
+                  </TableCell>
+                  <TableCell>{vuln.version}</TableCell>
+                  <TableCell sx={{ fontFamily: "monospace" }}>
+                    {vuln.cve}
+                  </TableCell>
+                  <TableCell
+                    sx={{ color: "text.secondary", maxWidth: 300 }}
+                    className="truncate"
+                  >
+                    {vuln.description}
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      color="secondary"
+                      startIcon={<Bot size={14} />}
+                      onClick={() => handleAiRemediation(vuln)}
+                      sx={{ textTransform: "none" }}
+                    >
+                      AI解説
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={6} align="center" sx={{ py: 8 }}>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "center",
+                      color: "text.secondary",
+                    }}
+                  >
+                    <Search size={40} />
+                    <Typography sx={{ mt: 1 }}>該当なし</Typography>
+                  </Box>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* AI ダイアログ */}
+      <Dialog
+        open={aiDialogOpen}
+        onClose={() => setAiDialogOpen(false)}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            bgcolor: "secondary.50",
+            color: "secondary.main",
+          }}
+        >
+          <Sparkles size={20} />
+          <Typography variant="h6" component="div" fontWeight="bold">
+            Gemini AI Analysis
+          </Typography>
+        </DialogTitle>
+        <DialogContent sx={{ minHeight: 300, p: 4 }}>
+          <Typography
+            variant="subtitle2"
+            color="text.secondary"
+            gutterBottom
+            sx={{ mb: 2 }}
+          >
+            {aiContext}
+          </Typography>
+          {aiLoading ? (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                height: 200,
+                gap: 2,
+              }}
+            >
+              <CircularProgress color="secondary" />
+              <Typography color="text.secondary" className="animate-pulse">
+                AIが分析中...
+              </Typography>
+            </Box>
+          ) : (
+            <Paper
+              variant="outlined"
+              sx={{
+                p: 3,
+                bgcolor: "grey.50",
+                whiteSpace: "pre-line",
+                lineHeight: 1.6,
+              }}
+            >
+              {aiResult.split("\n").map((l, i) => (
+                <Typography key={i} paragraph sx={{ mb: 1 }}>
+                  {l.startsWith("**") ? (
+                    <Box component="span" fontWeight="bold">
+                      {l.replace(/\*\*/g, "")}
+                    </Box>
+                  ) : (
+                    l
+                  )}
+                </Typography>
+              ))}
+            </Paper>
+          )}
+        </DialogContent>
+        <DialogActions sx={{ p: 2 }}>
+          <Button onClick={() => setAiDialogOpen(false)} color="inherit">
+            閉じる
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={() => setAiDialogOpen(false)}
+          >
+            理解しました
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,22 +1,10 @@
-import { notFound } from "next/navigation";
-import { getProjectById, getTeams } from "@/app/lib/data";
 import { ProjectDetailView } from "./ProjectDetailView";
 
-type PageProps = {
+export default async function ProjectDetailPage({
+  params,
+}: {
   params: Promise<{ id: string }>;
-};
-
-export default async function ProjectDetailPage({ params }: PageProps) {
+}) {
   const { id } = await params;
-  const [project, teams] = await Promise.all([getProjectById(id), getTeams()]);
-
-  if (!project) {
-    notFound();
-  }
-
-  // TODO: チーム選択は URL/Cookie で管理すべき。ここでは先頭チームを仮で使用
-  const currentTeam = teams.find((t) => t.id === project.teamId) ??
-    teams[0] ?? { id: "", name: "Unknown" };
-
-  return <ProjectDetailView project={project} currentTeam={currentTeam} />;
+  return <ProjectDetailView projectId={id} />;
 }


### PR DESCRIPTION
## 概要
プロジェクト詳細画面のコンポーネントを分離し、Server/Client Component の責務を明確化。

## 変更内容
- page.tsx を Thin page 化（データ取得を View に移動）
- VulnerabilitySection を Client Component として分離（フィルタ・ソート・AI機能）
- AiReportButton を独立コンポーネントとして抽出
- ProjectDetailView を Server Component としてデータ取得を担当

## 確認事項
- [x] ビルド成功
- [x] 型エラーなし