### PR TITLE
refactor: VulnerabilitySection の三項演算子ネストを解消

### DIFF
--- a/app/projects/[id]/VulnerabilitySection.tsx
+++ b/app/projects/[id]/VulnerabilitySection.tsx
@@ -26,6 +26,15 @@ import { SeverityChip } from "./SeverityChip";
 import { callGeminiAPI } from "../../lib/gemini";
 import type { Vulnerability, Severity } from "../../types";
 
+const getSeverityColor = (
+  severity: Severity | "All",
+): "default" | "error" | "warning" | "info" => {
+  if (severity === "All") return "default";
+  if (severity === "Critical" || severity === "High") return "error";
+  if (severity === "Medium") return "warning";
+  return "info";
+};
+
 export const VulnerabilitySection = ({
   vulnerabilities,
 }: {
@@ -123,15 +132,7 @@ export const VulnerabilitySection = ({
                 size="small"
                 variant={severityFilter === sev ? "filled" : "outlined"}
                 color={
-                  severityFilter === sev
-                    ? sev === "All"
-                      ? "default"
-                      : sev === "Critical" || sev === "High"
-                        ? "error"
-                        : sev === "Medium"
-                          ? "warning"
-                          : "info"
-                    : "default"
+                  severityFilter === sev ? getSeverityColor(sev) : "default"
                 }
                 onClick={() => setSeverityFilter(sev)}
                 sx={{ cursor: "pointer" }}


### PR DESCRIPTION
## 概要
VulnerabilitySection.tsx のカラー判定ロジックが三項演算子のネストで読みにくくなっていたため、ヘルパー関数に抽出してリファクタリング。

## 変更内容
- `getSeverityColor` 関数を追加
- インラインの三項演算子を関数呼び出しに置換

Closes #26