### PR TITLE
feat: package.json パーサーを追加

### DIFF
--- a/app/lib/parsers/packageJson.ts
+++ b/app/lib/parsers/packageJson.ts
@@ -1,0 +1,53 @@
+import { minVersion } from "semver";
+
+export type ParsedPackage = {
+  name: string;
+  version: string;
+  isDev: boolean;
+};
+
+type PackageJsonDeps = Record<string, string>;
+
+type PackageJsonContent = {
+  dependencies?: PackageJsonDeps;
+  devDependencies?: PackageJsonDeps;
+};
+
+function resolveVersion(range: string): string | null {
+  try {
+    const resolved = minVersion(range);
+    return resolved ? resolved.version : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractPackages(
+  deps: PackageJsonDeps | undefined,
+  isDev: boolean,
+): ParsedPackage[] {
+  if (!deps) return [];
+
+  return Object.entries(deps)
+    .map(([name, range]) => {
+      const version = resolveVersion(range);
+      if (!version) return null;
+      return { name, version, isDev };
+    })
+    .filter((pkg): pkg is ParsedPackage => pkg !== null);
+}
+
+export function parsePackageJson(content: string): ParsedPackage[] {
+  let parsed: PackageJsonContent;
+
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return [];
+  }
+
+  const deps = extractPackages(parsed.dependencies, false);
+  const devDeps = extractPackages(parsed.devDependencies, true);
+
+  return [...deps, ...devDeps];
+}


### PR DESCRIPTION
## 概要
`package.json` から依存パッケージを抽出するパーサーを実装しました。

## 変更内容
- `app/lib/parsers/packageJson.ts` を新規作成
- `dependencies` / `devDependencies` の抽出に対応
- `semver.minVersion` でバージョン範囲（`^`, `~` 等）を正規化
- 不正な JSON は空配列を返す

## 動作確認
```
Parsed packages:
  - react 16.8.0
  - lodash 4.17.15
  - typescript 4.0.0 (dev)

Invalid JSON result: Empty ✓
```

Closes #16