### PR TITLE
refactor: ESLintで未使用インポートを正しく検出できるよう設定を改善

### DIFF
--- a/app/components/AppHeader.tsx
+++ b/app/components/AppHeader.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from "react";
+import { Suspense } from "react";
 import Link from "next/link";
 import { AppBar, Toolbar, Button, Box } from "@mui/material";
 import { UploadCloud } from "lucide-react";

--- a/app/components/AppSnackbar.tsx
+++ b/app/components/AppSnackbar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import { Snackbar, Alert } from "@mui/material";
 import { useApp } from "../contexts/AppContext";
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Box,

--- a/app/projects/HeaderActions.tsx
+++ b/app/projects/HeaderActions.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import { useRouter } from "next/navigation";
 import { Box, Button } from "@mui/material";
 import { Search, Settings } from "lucide-react";

--- a/app/projects/[id]/AiReportButton.tsx
+++ b/app/projects/[id]/AiReportButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   Button,
   Dialog,

--- a/app/projects/[id]/VulnerabilitySection.tsx
+++ b/app/projects/[id]/VulnerabilitySection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import {
   Box,
   Typography,

--- a/app/settings/TeamSettings.tsx
+++ b/app/settings/TeamSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   Box,
   Typography,

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Box, Container, Button } from "@mui/material";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,16 +2,20 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import prettier from "eslint-config-prettier/flat";
+import unusedImports from "eslint-plugin-unused-imports";
+import react from "eslint-plugin-react";
 
-const eslintConfig = defineConfig([
+export default defineConfig([
   ...nextVitals,
   ...nextTs,
-  prettier,
+  react.configs.flat["jsx-runtime"],
   {
+    plugins: { "unused-imports": unusedImports },
     rules: {
-      "@typescript-eslint/no-unused-vars": "error",
+      "unused-imports/no-unused-imports": "error",
     },
   },
+  prettier,
   globalIgnores([
     ".next/**",
     "out/**",
@@ -20,5 +24,3 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
   ]),
 ]);
-
-export default eslintConfig;

--- a/knip.json
+++ b/knip.json
@@ -7,9 +7,7 @@
     "@prisma/client",
     "@eslint/eslintrc",
     "@eslint/js",
-    "@typescript-eslint/eslint-plugin",
     "@typescript-eslint/parser",
-    "eslint-plugin-react",
     "eslint-plugin-react-hooks",
     "globals"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-unused-imports": "^4.3.0",
         "globals": "^16.5.0",
         "knip": "^5.78.0",
         "prettier": "^3.7.4",
@@ -4952,6 +4953,22 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.3.0.tgz",
+      "integrity": "sha512-ZFBmXMGBYfHttdRtOG9nFFpmUvMtbHSjsKrS20vdWdbfiVYsO3yA2SGYy9i9XmZJDfMGBflZGBCm70SEnFQtOA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-unused-imports": "^4.3.0",
     "globals": "^16.5.0",
     "knip": "^5.78.0",
     "prettier": "^3.7.4",


### PR DESCRIPTION
## 変更内容

### ESLint設定の改善
- `eslint-plugin-unused-imports` を追加して未使用インポートを正しく検出
- `react.configs.flat["jsx-runtime"]` を追加（React 17+ の新しいJSX変換に対応）
- `@typescript-eslint/no-unused-vars` から `unused-imports/no-unused-imports` に変更

### 未使用インポートの削除
以下のファイルから不要な `React` 名前空間インポートを削除：
- `app/components/AppHeader.tsx`
- `app/components/AppSnackbar.tsx`
- `app/page.tsx`
- `app/projects/HeaderActions.tsx`
- `app/projects/[id]/AiReportButton.tsx`
- `app/projects/[id]/VulnerabilitySection.tsx`
- `app/settings/TeamSettings.tsx`
- `app/settings/page.tsx`

### その他
- `knip.json` から不要な除外設定を削除

## 背景
React 17以降では、JSX変換時に自動的にReactをインポートするため、`import React` は不要になりました。
しかし、既存のESLint設定ではJSXファイル内の未使用 `React` インポートを検出できていませんでした。
`eslint-plugin-react` の `jsx-runtime` 設定を追加することで、この問題を解決しました。