### PR TITLE
test: add view model unit tests

### DIFF
--- a/app/lib/__tests__/viewModel.test.ts
+++ b/app/lib/__tests__/viewModel.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { convertToUIProject, type ProjectViewModelSource } from "../viewModel";
+
+describe("convertToUIProject", () => {
+  it("flattens vulnerabilities and maps severity", () => {
+    const input: ProjectViewModelSource = {
+      id: "project-1",
+      teamId: "team-1",
+      name: "Sample",
+      fileName: "package.json",
+      uploadDate: new Date("2025-01-01T00:00:00Z"),
+      status: "completed",
+      pkgCount: 3,
+      errorMessage: null,
+      packages: [
+        {
+          name: "left-pad",
+          version: "1.3.0",
+          vulnerability: {
+            id: "vuln-1",
+            severity: "HIGH",
+            cve: "CVE-2024-0001",
+            description: "desc",
+          },
+        },
+        {
+          name: "no-vuln",
+          version: "2.0.0",
+          vulnerability: null,
+        },
+        {
+          name: "legacy",
+          version: "0.9.0",
+          vulnerability: {
+            id: "vuln-2",
+            severity: "low",
+            cve: null,
+            description: "desc2",
+          },
+        },
+      ],
+    };
+
+    const result = convertToUIProject(input);
+
+    expect(result.vulnerabilities).toEqual([
+      {
+        id: "vuln-1",
+        packageName: "left-pad",
+        version: "1.3.0",
+        severity: "High",
+        cve: "CVE-2024-0001",
+        description: "desc",
+      },
+      {
+        id: "vuln-2",
+        packageName: "legacy",
+        version: "0.9.0",
+        severity: "Low",
+        cve: "N/A",
+        description: "desc2",
+      },
+    ]);
+  });
+
+  it("maps null errorMessage to undefined", () => {
+    const input: ProjectViewModelSource = {
+      id: "project-2",
+      teamId: "team-2",
+      name: "Sample 2",
+      fileName: "package-lock.json",
+      uploadDate: new Date("2025-01-02T00:00:00Z"),
+      status: "failed",
+      pkgCount: 0,
+      errorMessage: null,
+      packages: [],
+    };
+
+    const result = convertToUIProject(input);
+
+    expect(result.errorMessage).toBeUndefined();
+  });
+});

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -1,21 +1,7 @@
 import { prisma } from "@/lib/prisma";
-import type { Project, Vulnerability, Severity } from "@/app/types";
+import type { Project } from "@/app/types";
 import { Prisma } from "../../generated/prisma/client";
-
-// 重要度文字列をUIの型に変換
-const mapSeverity = (severity: string): Severity => {
-  switch (severity.toLowerCase()) {
-    case "critical":
-      return "Critical";
-    case "high":
-      return "High";
-    case "medium":
-      return "Medium";
-    case "low":
-    default:
-      return "Low";
-  }
-};
+import { convertToUIProject } from "./viewModel";
 
 type ProjectWithPackages = Prisma.ProjectGetPayload<{
   include: {
@@ -44,35 +30,6 @@ export async function getProjects(teamId?: string): Promise<Project[]> {
   });
 
   return projects.map((p: ProjectWithPackages) => convertToUIProject(p));
-}
-
-function convertToUIProject(p: ProjectWithPackages): Project {
-  // Project -> Package -> Vulnerability の構造をフラットな Vulnerability 配列に変換
-  const vulnerabilities: Vulnerability[] = p.packages
-    .filter((pkg) => pkg.vulnerability) // 脆弱性があるパッケージのみ
-    .map((pkg) => {
-      const v = pkg.vulnerability!;
-      return {
-        id: v.id,
-        packageName: pkg.name,
-        version: pkg.version,
-        severity: mapSeverity(v.severity),
-        cve: v.cve || "N/A",
-        description: v.description,
-      };
-    });
-
-  return {
-    id: p.id,
-    teamId: p.teamId,
-    name: p.name,
-    fileName: p.fileName,
-    uploadDate: p.uploadDate,
-    status: p.status as "analyzing" | "completed" | "failed",
-    vulnerabilities: vulnerabilities,
-    pkgCount: p.pkgCount,
-    errorMessage: p.errorMessage || undefined,
-  };
 }
 
 // 単一プロジェクトを ID で取得

--- a/app/lib/viewModel.ts
+++ b/app/lib/viewModel.ts
@@ -1,0 +1,68 @@
+import type { Project, Severity, Vulnerability } from "@/app/types";
+
+type PackageWithVulnerability = {
+  name: string;
+  version: string;
+  vulnerability: {
+    id: string;
+    severity: string;
+    cve: string | null;
+    description: string;
+  } | null;
+};
+
+export type ProjectViewModelSource = {
+  id: string;
+  teamId: string;
+  name: string;
+  fileName: string;
+  uploadDate: Date;
+  status: string;
+  pkgCount: number;
+  errorMessage?: string | null;
+  packages: PackageWithVulnerability[];
+};
+
+// 重要度文字列をUIの型に変換
+const mapSeverity = (severity: string): Severity => {
+  switch (severity.toLowerCase()) {
+    case "critical":
+      return "Critical";
+    case "high":
+      return "High";
+    case "medium":
+      return "Medium";
+    case "low":
+    default:
+      return "Low";
+  }
+};
+
+export function convertToUIProject(p: ProjectViewModelSource): Project {
+  // Project -> Package -> Vulnerability の構造をフラットな Vulnerability 配列に変換
+  const vulnerabilities: Vulnerability[] = p.packages
+    .filter((pkg) => pkg.vulnerability)
+    .map((pkg) => {
+      const v = pkg.vulnerability!;
+      return {
+        id: v.id,
+        packageName: pkg.name,
+        version: pkg.version,
+        severity: mapSeverity(v.severity),
+        cve: v.cve || "N/A",
+        description: v.description,
+      };
+    });
+
+  return {
+    id: p.id,
+    teamId: p.teamId,
+    name: p.name,
+    fileName: p.fileName,
+    uploadDate: p.uploadDate,
+    status: p.status as "analyzing" | "completed" | "failed",
+    vulnerabilities: vulnerabilities,
+    pkgCount: p.pkgCount,
+    errorMessage: p.errorMessage || undefined,
+  };
+}


### PR DESCRIPTION
## 概要
- ViewModelの変換ロジックをユニットテスト化
- 変換処理を `app/lib/viewModel.ts` に分離

## 変更点
- `convertToUIProject` の変換結果をテスト
  - 重要度のマッピング
  - vulnerabilityのフラット化
  - `cve` が null の場合の "N/A"
  - `errorMessage` の null→undefined
- `app/lib/data.ts` から変換ロジックを切り出し

## テスト
- `npm test`
