### PR TITLE
Add upload error e2e tests

### DIFF
--- a/tests/e2e/upload-errors.spec.ts
+++ b/tests/e2e/upload-errors.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+import {
+  createOversizeJsonFile,
+  createTempFile,
+  getFixturePath,
+} from "./utils";
+
+const fileInput = (page: { locator: (selector: string) => any }) =>
+  page.locator('input[type="file"]');
+
+const errorAlert = (page: { getByRole: (role: string) => any }) =>
+  page.getByRole("alert");
+
+const toastByMessage = (page: { getByText: (text: string) => any }, message: string) =>
+  page.getByText(message, { exact: false });
+
+test("shows error for empty file", async ({ page }) => {
+  await page.goto("/");
+  await fileInput(page).setInputFiles(getFixturePath("empty.json"));
+
+  await expect(errorAlert(page)).toContainText("空のファイルです");
+  await expect(toastByMessage(page, "空のファイルです")).toBeVisible();
+});
+
+test("shows error for invalid JSON", async ({ page }) => {
+  await page.goto("/");
+  await fileInput(page).setInputFiles(getFixturePath("invalid.json"));
+
+  await expect(errorAlert(page)).toContainText("JSONとして解析できません");
+  await expect(toastByMessage(page, "JSONとして解析できません")).toBeVisible();
+});
+
+test("shows error for non-json extension", async ({ page }) => {
+  await page.goto("/");
+  const filePath = await createTempFile("{}", "txt");
+  await fileInput(page).setInputFiles(filePath);
+  await expect(errorAlert(page)).toContainText("JSON ファイルのみ対応しています");
+  await expect(toastByMessage(page, "JSON ファイルのみ対応しています")).toBeVisible();
+});
+
+test("shows error for oversize file", async ({ page }) => {
+  await page.goto("/");
+  const oversizePath = await createOversizeJsonFile();
+  await fileInput(page).setInputFiles(oversizePath);
+
+  await expect(errorAlert(page)).toContainText("5MBを超えています");
+  await expect(toastByMessage(page, "5MBを超えています")).toBeVisible();
+});

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -8,9 +8,9 @@ const fixturesDir = resolve(currentDir, "..", "fixtures");
 
 export const getFixturePath = (name: string) => resolve(fixturesDir, name);
 
-export const createTempJsonFile = async (content: string) => {
+export const createTempFile = async (content: string, extension = "json") => {
   const dir = await fs.mkdtemp(join(tmpdir(), "vuln-e2e-"));
-  const filePath = join(dir, "temp.json");
+  const filePath = join(dir, `temp.${extension}`);
   await fs.writeFile(filePath, content, "utf8");
   return filePath;
 };
@@ -20,5 +20,5 @@ export const createOversizeJsonFile = async (
 ) => {
   const payload = "x".repeat(minSizeBytes);
   const content = JSON.stringify({ data: payload });
-  return createTempJsonFile(content);
+  return createTempFile(content, "json");
 };


### PR DESCRIPTION
## Summary\n- add Playwright tests for upload error cases (empty/invalid/non-json/oversize)\n- update e2e utils for temp file creation\n\n## Testing\n- Not run (Playwright browsers not installed)\n\nCloses #60